### PR TITLE
Remove date posted from payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ and
   "sourceSystem": "SITIAgri",
   "invoiceNumber": "S123456789A123456V001",
   "frn": 1234567890,
-  "postedDate": "Fri Jan 21 2022 10:38:44 GMT+0000 (Greenwich Mean Time)",
   "currency": "GBP",
   "value": 10000,
   "settlementDate": "Fri Jan 21 2022 10:38:44 GMT+0000 (Greenwich Mean Time)",

--- a/app/processing/parse-return-file.js
+++ b/app/processing/parse-return-file.js
@@ -9,7 +9,6 @@ const parseReturnFile = async (content) => {
       sourceSystem: row[0],
       invoiceNumber: row[1],
       frn: Number(row[2]),
-      postedDate: row[4] !== '' ? new Date(row[4]) : undefined,
       currency: row[5] === 'S' ? 'GBP' : row[5],
       value: convertToPence(row[6]),
       settlementDate: row[7] !== '' ? moment(row[7], ['YYYY-MM-DD', 'DD/MM/YYYY']).toISOString() : undefined,

--- a/docs/asyncapi.yaml
+++ b/docs/asyncapi.yaml
@@ -48,9 +48,6 @@ components:
           frn:
             type: number
             description: Firm Reference Number
-          postedDate:
-            type: string
-            description: Date posted in DAX
           currency:
             type: string
             description: Currency request settled in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-pay-responses",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "FFC payment response processing",
   "homepage": "https://github.com/DEFRA/ffc-pay-responses",
   "main": "app/index.js",


### PR DESCRIPTION
Date posted is not consumed by downstream services and the format from DAX can be unexpected.  Therefore removing it from the payload de-risks the service.